### PR TITLE
Removed % symbol at end of the scripts (typo)

### DIFF
--- a/.sleep
+++ b/.sleep
@@ -19,4 +19,4 @@ while IFS= read -r service; do
     if [[ $service != \** ]]; then
         networksetup -setnetworkserviceenabled "$service" off
     fi
-done <<< "$services"%
+done <<< "$services"

--- a/.wakeup
+++ b/.wakeup
@@ -16,4 +16,4 @@ while IFS= read -r service; do
     if [[ $service == \** ]]; then
         networksetup -setnetworkserviceenabled "${service//\*}" on
     fi
-done <<< "$services"%
+done <<< "$services"


### PR DESCRIPTION
I'm very sorry, in my last PR I introduced a bug, which completley broke both scripts.
Somehow I did a copy/paste error and added a symbol "%" at the bottom line which completely breaks the scripts.

This is the fix which removes the obsolete symbol.